### PR TITLE
Clear accumulated wattseconds prior to EVSE_STATE_DISABLED

### DIFF
--- a/J1772EvseController.cpp
+++ b/J1772EvseController.cpp
@@ -445,6 +445,12 @@ void J1772EVSEController::Enable()
 
 void J1772EVSEController::Disable()
 {
+#ifdef KWH_RECORDING   // Reset the Wh when exiting State A for any reason
+  if (m_EvseState == EVSE_STATE_A) {
+    g_WattSeconds = 0;
+  }
+#endif
+
   if (m_EvseState != EVSE_STATE_DISABLED) { 
     m_Pilot.SetState(PILOT_STATE_N12);
     m_EvseState = EVSE_STATE_DISABLED;


### PR DESCRIPTION
(Note, I've not tested this, I bet Chris is in a position to do so easily - sorry!
It seems obviously correct though - famous last words?)

https://openev.freshdesk.com/support/discussions/topics/6000046121?page=1
has a report from a user that disabling and re-enabling the unit
will cause the lifetime watt-hour display to increase by the
last session's watt-second total on each disable/enable cycle.

This is because going into the disabled state does not clear the
watt-second counter, and when we re-enable it and transition to
EVSE_STATE_A, it will add `g_WattSeconds` to `g_WattHours_accumulated`
each time.

Fix this by setting wattseconds to 0 prior to disabling the unit,
similar to what is done prior to Sleep().

Signed-off-by: Eric Sandeen <sandeen@sandeen.net>