### PR TITLE
Update open_evse.ino

### DIFF
--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -1770,8 +1770,8 @@ Menu *RTCMenuDay::Select()
 RTCMenuYear::RTCMenuYear()
 {
 }
-#define YEAR_MIN 18
-#define YEAR_MAX 28
+#define YEAR_MIN 21
+#define YEAR_MAX 31
 void RTCMenuYear::Init()
 {
   g_OBD.LcdPrint_P(0,g_psRTC_Year);


### PR DESCRIPTION
If Real-Time Clock isn't set, and if we're not setting via the wifi module then the YEAR_MIN should be a bit more recent to save button pushes.
Perhaps YEAR_MAX for the pushbutton menu interface should be more than 10 years later? What's the expected lifespan of this system before we'd expect firmware updates to be applied?