### PR TITLE
v8.1.1 merge

### DIFF
--- a/doc/mennekes-lock.md
+++ b/doc/mennekes-lock.md
@@ -1,0 +1,76 @@
+# Mennekes lock
+
+
+Mennekes lock is the mechanism for locking a charging cable into a non-tethered socket (IEC 62196-2). The purpose of the lock is to avoid the hazard of the cable being disconnected during a charging session and secure the cable to avoid theft. 
+
+
+IEC 62196-2 enabled vehicles (all vehicles sold in Europe) also lock the cable at the vehicle end, usually there is a button on the keyfob and or dashboard to unlock the vehicle end of the cable which also stops the changing session. 
+
+
+## Firmware 
+
+
+This documentation references openevse controller firmware 
+
+
+Controller Firmware: V8.1.0a+
+RAPI: V5.2.0
+Issue: https://github.com/lincomatic/open_evse/issues/141
+
+
+To enable Mennekes lock uncomment `#define MENNEKES_LOCK` in `open_evse.h`
+
+
+## Hardware connections 
+
+
+Mennekes lock currently uses the ISP pins as digital out pins
+
+
+MOSI - Pin A - LOCK
+MISO - Pin B - UNLOCK
+
+
+Mennekes lock requires a 12V H-bridge, tested with L298N duel H-bridge drive
+
+
+## Operation 
+
+
+Mennekes lock has both automatic and manual operation 
+
+
+### Automatic 
+
+
+The Mennekes lock will be activated (locked) when a vehicle is connected and will be unlocked when a vehicle is disconnected. To disconnect a vehicle the vehicle end of the cable should be unlocked first. **Automatic is default mode,**
+
+
+#### Manual 
+
+
+Manuel operation mode was introduced to allow the Mennekes lock to be controlled by ESP32 WiFi module via RAPI. Manual mode could be controlled via OCPP, HTTP API manually via the web interface. Manual mode could allow the user to permanently lock the cable into the socket, e.g to prevent cable theft for home use when the cable is left permanently in between charging sessions. **Manual mode is volatile, the unit will always boot into automatic mode**
+
+
+##### RAPI 
+
+
+```
+S5 A|M|0|1 - Mennekes lock setting
+   A = enable automatic mode - locked when connected, unlocked otherwise
+   M = enable manual control mode
+   0 = unlock (valid only in manual mode)
+   1 = lock (valid only in manual mode)
+   n.b. requires MENNEKES_LOCK. manual mode is volatile - always boots in automatic mode
+```
+
+```
+G5 - get Mennekes settings
+ response: $OK state mode
+   state: 0 = unlocked
+          1 = locked
+   mode: A = automatic mode - locked when connected, unlocked otherwise
+         M = manual control mode
+   Note: lock mode is also indicated by ECVF_MENNEKES_MANUAL
+   n.b. requires MENNEKES_LOCK
+```

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,8 @@
 Change Log
 
+20220107
+- set ECF_AUTO_SVC_LEVEL_DISABLED when !AUTOSVCLEVEL
+
 20211216 SCL V8.1.1
 - reset elapsed time when car plugged in
 - J1772EvseController::Update() - just call ReadPilot() once at the top of function

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,9 @@
 Change Log
 
+20211216 SCL V8.1.0
+- merged in mennekes branch
+- change version number
+	
 20211201 SCL V8.1.0a
 - added ECVF_TIMER_ON so we don't have to poll to test if delay timer is on
 - revamp MENNEKES_LOCK

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,22 @@
 Change Log
 
+20211201 SCL V8.1.0a
+- added ECVF_TIMER_ON so we don't have to poll to test if delay timer is on
+- revamp MENNEKES_LOCK
+  -> auto mode: locked when EVSE connected, unlocked when disconnected
+     -> to implement this, need to get rid of states were pilot = N12, because
+	we can't detect connection state
+	-> don't ever set pilot to N12, even in fault states. only set to N12 
+	in EVSE_STATE_DISABLED
+	  -> always automatically unlocks in EVSE_STATE_DISABLED, even if
+	  in manual mode
+	-> add recoverable parameter to HardFault()
+  -> add volatile manual mode - when enabled, Mennekes lock is under full manual
+	control
+  -> add S5/G5 RAPI commands to set/fetch Mennekes settings
+  -> ECVF_MENNEKES_MANUAL also reflects auto/manual mode
+- RAPIVER 5.2.0
+- usurped ECVF_AMMETER_CAL with ECVF_MENNEKES_MANUAL, so the code is currently turned off
 20211201 SCL V8.0.0d
 - more refinements to CGMI - POST stuck relay check
 20211128 SCL V8.0.0c

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,18 @@
 Change Log
 
+20211201 SCL V8.0.0d
+- more refinements to CGMI - POST stuck relay check
+20211128 SCL V8.0.0c
+- fixed bugs in CGMI code
+20211123 SCL V8.0.0a
+- acpinstate: added ACPINx_OPEN
+- first cut for CGMI - continuous GMI support:
+  -> PD4: at any time, if PD3 is low, declare EVSE_STATE_NO_GROUND.
+  -> PD3: we will read it only when we think the relay should be open. If we detect a low state on PD4 when the relay is supposed to be open, go to EVSE_STATE_STUCK_RELAY. This is exactly the current behavior, except that we only monitor one pin.	
+- take out SAMPLE_ACPINS #ifdef.. always sample
+- added INVERT_V6_DETECTION: DO NOT USE 
+  -> only enabled for lincomatic's beta V6 board
+	
 2021119 SCL V7.1.6
 - fixed bug - RAPI $GI was implemented as $SI
 - fixed bug, $GI was returning $OK $GI xxx

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,10 @@
 Change Log
 
+20211216 SCL V8.1.1
+- reset elapsed time when car plugged in
+- J1772EvseController::Update() - just call ReadPilot() once at the top of function
+  -> previously had ReadPilot() sprinkled around to try to avoid reading when not needed to save CPU cycles -> probably not necssary
+
 20211216 SCL V8.1.0
 - merged in mennekes branch
 - change version number

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -1016,8 +1016,9 @@ void J1772EVSEController::Init()
     svclvl = GetCurSvcLevel();
   }
 
-  // FORCE CGMI ON - TAKE THIS CODE OUT
+#ifdef ENABLE_CGMI
   m_wFlags |= ECF_CGMI;
+#endif // ENABLE_CGMI
 
   if (CGMIisEnabled() && !flagIsSet(ECF_AUTO_SVC_LEVEL_DISABLED)) {
     // can't do auto svc level when CGMI enabled, revert to default

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -1233,9 +1233,11 @@ void J1772EVSEController::Update(uint8_t forcetransition)
     m_PrevEvseState = m_EvseState; // cancel state transition
     return;
   }
-  else if (m_EvseState == EVSE_STATE_SLEEPING) {
-    ReadPilot(&plow,&phigh); // always read so we can update EV connect state, too
 
+  ReadPilot(&plow,&phigh); // always read so we can update EV connect state, too
+
+
+  if (m_EvseState == EVSE_STATE_SLEEPING) {
     int8_t cancelTransition = 1;
     if (chargingIsOn()) {
       // wait for pilot voltage to go > STATE C. This will happen if
@@ -1360,9 +1362,6 @@ void J1772EVSEController::Update(uint8_t forcetransition)
     else { // !chargingIsOn() - relay open
       if (!CGMIisEnabled() && (prevevsestate == EVSE_STATE_NO_GROUND)) {
         // check to see if EV disconnected
-        if (phigh == 0xffff) {
-          ReadPilot();  // update EV connect state
-        }
         if (!EvConnected()) {
           // EV disconnected - cancel fault
           m_EvseState = EVSE_STATE_UNKNOWN;
@@ -1419,8 +1418,6 @@ void J1772EVSEController::Update(uint8_t forcetransition)
       m_GfiFaultStartMs = curms;
     }
     else { // was already in GFI fault
-      // check to see if EV disconnected
-      ReadPilot();  // update EV connect state
       if (!EvConnected()) {
 	// EV disconnected - cancel fault
 	m_EvseState = EVSE_STATE_UNKNOWN;
@@ -1474,8 +1471,6 @@ if (TempChkEnabled()) {
       prevevsestate = EVSE_STATE_UNKNOWN;
       m_EvseState = EVSE_STATE_UNKNOWN;
     }
-
-    ReadPilot(&plow,&phigh);
 
     if (DiodeCheckEnabled() && (m_Pilot.GetState() == PILOT_STATE_PWM) && (plow >= m_ThreshData.m_ThreshDS)) {
       // diode check failed

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -1236,6 +1236,12 @@ void J1772EVSEController::Update(uint8_t forcetransition)
 
   ReadPilot(&plow,&phigh); // always read so we can update EV connect state, too
 
+  if (EvConnectedTransition()) {
+    if (EvConnected()) {
+      m_AccumulatedChargeTime = 0;
+      m_ElapsedChargeTime = 0;
+    }
+  }
 
   if (m_EvseState == EVSE_STATE_SLEEPING) {
     int8_t cancelTransition = 1;

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -1787,7 +1787,11 @@ if (TempChkEnabled()) {
   ReadVoltmeter();
 #endif // VOLTMETER
 #ifdef AMMETER
-  if (((m_EvseState == EVSE_STATE_C) && (m_CurrentScaleFactor > 0)) || AmmeterCalEnabled()) {
+  if (((m_EvseState == EVSE_STATE_C) && (m_CurrentScaleFactor > 0))
+#ifdef ECVF_AMMETER_CAL  
+      || AmmeterCalEnabled()
+#endif
+      ) {
     
 #ifndef FAKE_CHARGING_CURRENT
     readAmmeter();

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -1017,6 +1017,10 @@ void J1772EVSEController::Init()
     svclvl = GetCurSvcLevel();
   }
 
+#ifndef AUTOSVCLEVEL
+  m_wFlags |= ECF_AUTO_SVC_LEVEL_DISABLED;
+#endif
+
 #ifdef ENABLE_CGMI
   m_wFlags |= ECF_CGMI;
 #endif // ENABLE_CGMI

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -389,7 +389,7 @@ public:
   uint8_t ReadACPins();
 #endif // ADVPWR
 
-  void HardFault();
+  void HardFault(uint8_t recoverable);
 
   void SetLimitSleep(int8_t tf) {
     if (tf) setVFlags(ECVF_LIMIT_SLEEP);

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -103,7 +103,7 @@ typedef uint8_t (*EvseStateTransitionReqFunc)(uint8_t prevPilotState,uint8_t cur
 #define ECVF_TIMER_ON           0x1000 // delay timer enabled
 #define ECVF_CHARGE_LIMIT       0x2000
 // reserved #define ECVF_BOOT_LOCK          0x4000 // locked at boot
-#define ECVF_AMMETER_CAL        0x8000
+#define ECVF_MENNEKES_MANUAL    0x8000 // Mennekes lock manual mode
 #if defined(AUTH_LOCK) && (AUTH_LOCK != 0)
 #define ECVF_DEFAULT            ECVF_AUTH_LOCKED|ECVF_SESSION_ENDED
 #else
@@ -470,6 +470,7 @@ int GetHearbeatTrigger();
     m_CurrentScaleFactor = scale;
     eeprom_write_word((uint16_t*)EOFS_CURRENT_SCALE_FACTOR,scale);
   }
+#ifdef ECVF_AMMETER_CAL
   uint8_t AmmeterCalEnabled() { 
     return vFlagIsSet(ECVF_AMMETER_CAL);
   }
@@ -477,6 +478,7 @@ int GetHearbeatTrigger();
     if (tf) setVFlags(ECVF_AMMETER_CAL);
     else clrVFlags(ECVF_AMMETER_CAL);
   }
+#endif // ECVF_AMMETER_CAL
   void ZeroChargingCurrent() { m_ChargingCurrent = 0; }
   uint8_t GetInstantaneousChargingAmps() {
     readAmmeter();

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -2,7 +2,7 @@
 /*
  * This file is part of Open EVSE.
  *
- * Copyright (c) 2011-2021 Sam C. Lin
+ * Copyright (c) 2011-2019 Sam C. Lin
  *
  * Open EVSE is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -100,7 +100,9 @@ typedef uint8_t (*EvseStateTransitionReqFunc)(uint8_t prevPilotState,uint8_t cur
 #define ECVF_SESSION_ENDED      0x0200 // used for charging session time calc
 #define ECVF_EV_CONNECTED_PREV  0x0400 // prev EV connected flag
 #define ECVF_UI_IN_MENU         0x0800 // onboard UI currently in a menu
+#define ECVF_TIMER_ON           0x1000 // delay timer enabled
 #define ECVF_CHARGE_LIMIT       0x2000
+// reserved #define ECVF_BOOT_LOCK          0x4000 // locked at boot
 #define ECVF_AMMETER_CAL        0x8000
 #if defined(AUTH_LOCK) && (AUTH_LOCK != 0)
 #define ECVF_DEFAULT            ECVF_AUTH_LOCKED|ECVF_SESSION_ENDED
@@ -553,6 +555,8 @@ int GetHearbeatTrigger();
   }
   void SetInMenu() { setVFlags(ECVF_UI_IN_MENU); }
   void ClrInMenu() { clrVFlags(ECVF_UI_IN_MENU); }
+  void SetDelayTimerOnFlag() {setVFlags(ECVF_TIMER_ON); }
+  void ClrDelayTimerOnFlag() {clrVFlags(ECVF_TIMER_ON); }
 #ifdef BTN_MENU
   void ButtonEnable(uint8_t tf) {
     if (!tf) setFlags(ECF_BUTTON_DISABLED); 

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -2,7 +2,7 @@
 /*
  * This file is part of Open EVSE.
  *
- * Copyright (c) 2011-2019 Sam C. Lin
+ * Copyright (c) 2011-2021 Sam C. Lin
  *
  * Open EVSE is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -389,7 +389,7 @@ public:
   uint8_t ReadACPins();
 #endif // ADVPWR
 
-  void HardFault(uint8_t recoverable);
+  void HardFault(int8_t recoverable);
 
   void SetLimitSleep(int8_t tf) {
     if (tf) setVFlags(ECVF_LIMIT_SLEEP);
@@ -572,6 +572,15 @@ int GetHearbeatTrigger();
   void SetMV(uint32_t mv) { m_Voltage = mv; }
 #endif
   int32_t GetVoltage() { return m_Voltage; }
+#ifdef MENNEKES_LOCK
+  void SetMennekesManual() { m_wVFlags |= ECVF_MENNEKES_MANUAL; }
+  void ClrMennekesManual() { m_wVFlags &= ~ECVF_MENNEKES_MANUAL; }
+  int8_t MennekesIsManual() { return (m_wVFlags & ECVF_MENNEKES_MANUAL) ? 1 : 0; }
+  int8_t MennekesIsLocked() { return m_MennekesLock.IsLocked(); }
+  void LockMennekes() { m_MennekesLock.Lock(1); }
+  void UnlockMennekes() { m_MennekesLock.Unlock(1); }
+#endif // MENNEKES_LOCK
+
 };
 
 #ifdef FT_ENDURANCE

--- a/firmware/open_evse/Language_default.h
+++ b/firmware/open_evse/Language_default.h
@@ -59,7 +59,7 @@
 #define STR_STUCK_RELAY				  "STUCK RELAY"
 #define STR_DISABLED				   "Disabled"
 #define STR_RESETTING                              "Restarting..."
-
+#define STR_RELAY_CLOSURE_FAULT "OPEN RELAY"
 #define STR_WAITING					   "Waiting"
 #define STR_SLEEPING				   "Sleeping"
 #define STR_CONNECTED			     "Connected"

--- a/firmware/open_evse/MennekesLock.cpp
+++ b/firmware/open_evse/MennekesLock.cpp
@@ -2,7 +2,7 @@
 /*
  * Open EVSE Firmware
  *
- * Copyright (c) 2013-2014 Sam C. Lin <lincomatic@gmail.com>
+ * Copyright (c) 2013-2021 Sam C. Lin <lincomatic@gmail.com>
  *
  * This file is part of Open EVSE.
 
@@ -30,25 +30,31 @@ void MennekesLock::Init()
   pinA.init(MENNEKES_LOCK_PINA_REG,MENNEKES_LOCK_PINA_IDX,DigitalPin::OUT);
   pinB.init(MENNEKES_LOCK_PINB_REG,MENNEKES_LOCK_PINB_IDX,DigitalPin::OUT);
 
-  Unlock();
+  Unlock(1);
 }
 
-void MennekesLock::Lock()
+void MennekesLock::Lock(int8_t force)
 {
-  pinA.write(1);
-  pinB.write(0);
-  delay(300);
-  pinA.write(0);
-  pinB.write(0);
+  if (force || !isLocked) {
+    pinA.write(1);
+    pinB.write(0);
+    delay(300);
+    pinA.write(0);
+    pinB.write(0);
+    isLocked = 1;
+  }
 }
 
-void MennekesLock::Unlock()
+void MennekesLock::Unlock(int8_t force)
 {
-  pinA.write(0);
-  pinB.write(1);
-  delay(300);
-  pinA.write(0);
-  pinB.write(0);
+  if (force || isLocked) {
+    pinA.write(0);
+    pinB.write(1);
+    delay(300);
+    pinA.write(0);
+    pinB.write(0);
+    isLocked = 0;
+  }
 }
 
 #endif // MENNEKES_LOCK

--- a/firmware/open_evse/MennekesLock.h
+++ b/firmware/open_evse/MennekesLock.h
@@ -2,7 +2,7 @@
 /*
  * Open EVSE Firmware
  *
- * Copyright (c) 2016 Sam C. Lin <lincomatic@gmail.com>
+ * Copyright (c) 2013-2021 Sam C. Lin <lincomatic@gmail.com>
  *
  * This file is part of Open EVSE.
 
@@ -24,11 +24,13 @@
 #pragma once
 
 class MennekesLock {
+  int8_t isLocked;
   DigitalPin pinA;
   DigitalPin pinB;
  public:
   MennekesLock() {}
   void Init();
-  void Lock();
-  void Unlock();
+  void Lock(int8_t force);
+  void Unlock(int8_t force);
+  int8_t IsLocked() { return isLocked; }
 };

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -41,7 +41,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D8.1.0a"
+#define VERSION "D8.1.0"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -41,7 +41,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D8.1.0"
+#define VERSION "D8.1.1"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -59,7 +59,7 @@ typedef unsigned long time_t;
 #ifdef OEV6
 //#define INVERT_V6_DETECTION // DO NOT USE: ONLY FOR lincomatic's BETA V6 board
 #define RELAY_PWM
-#define RELAY_HOLD_DELAY_TUNING // enable Z0
+//#define RELAY_HOLD_DELAY_TUNING // enable Z0
 #endif // OEV6
 
 // enable CGMI support

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -41,7 +41,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D8.0.0d"
+#define VERSION "D8.1.0a"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer
@@ -130,7 +130,7 @@ extern AutoCurrentCapacityController g_ACCController;
 #define TIME_LIMIT
 
 // support Mennekes (IEC 62196) type 2 locking pin
-//#define MENNEKES_LOCK
+#define MENNEKES_LOCK
 
 // Support for Nick Sayer's OpenEVSE II board, which has alternate hardware for ground check/stuck relay check and a voltmeter for L1/L2.
 //#define OPENEVSE_2
@@ -486,8 +486,6 @@ extern AutoCurrentCapacityController g_ACCController;
 
 #ifdef MENNEKES_LOCK
 // requires external 12V H-bridge driver such as Polulu 1451
-#define MENNEKES_LOCK_STATE EVSE_STATE_B // lock in State B
-//#define MENNEKES_LOCK_STATE EVSE_STATE_C // lock in State C
 
 //D11 - MOSI
 #define MENNEKES_LOCK_PINA_REG &PINB

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -62,6 +62,9 @@ typedef unsigned long time_t;
 #define RELAY_HOLD_DELAY_TUNING // enable Z0
 #endif // OEV6
 
+// enable CGMI support
+//#define ENABLE_CGMI
+
 // enable $GI
 #define MCU_ID_LEN 10
 

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -41,7 +41,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D7.1.6"
+#define VERSION "D8.0.0d"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -2279,6 +2279,10 @@ void DelayTimer::Init() {
   else {
     m_DelayTimerEnabled = rtmp;
   }
+
+  if (m_DelayTimerEnabled) g_EvseController.SetDelayTimerOnFlag();
+  else g_EvseController.ClrDelayTimerOnFlag();
+
   rtmp = eeprom_read_byte((uint8_t*)EOFS_TIMER_START_HOUR);
   if (rtmp == 0xff) { // uninitialized EEPROM
     m_StartTimerHour = DEFAULT_START_HOUR;
@@ -2397,6 +2401,7 @@ void DelayTimer::Enable(){
   ClrManualOverride();
   //  g_EvseController.SaveSettings();
   //  CheckTime();
+  g_EvseController.SetDelayTimerOnFlag();
   g_OBD.Update(OBD_UPD_FORCE);
 }
 void DelayTimer::Disable(){
@@ -2404,6 +2409,7 @@ void DelayTimer::Disable(){
   eeprom_write_byte((uint8_t*)EOFS_TIMER_FLAGS, m_DelayTimerEnabled);
   ClrManualOverride();
   //  g_EvseController.SaveSettings();
+  g_EvseController.ClrDelayTimerOnFlag();
   g_OBD.Update(OBD_UPD_FORCE);
 }
 void DelayTimer::PrintTimerIcon(){

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -2,7 +2,7 @@
 /*
  * Open EVSE Firmware
  *
- * Copyright (c) 2011-2019 Sam C. Lin
+ * Copyright (c) 2011-2021 Sam C. Lin
  * Copyright (c) 2011-2014 Chris Howell <chris1howell@msn.com>
  * timer code Copyright (c) 2013 Kevin L <goldserve1@hotmail.com>
  * portions Copyright (c) 2014-2015 Nick Sayer <nsayer@kfu.com>

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -834,7 +834,11 @@ void OnboardDisplay::Update(int8_t updmode)
 
 #ifdef LCD16X2
 #if defined(AMMETER)
-    if (((curstate == EVSE_STATE_C) || g_EvseController.AmmeterCalEnabled()) && AmmeterIsDirty()) {
+    if (((curstate == EVSE_STATE_C)
+#ifdef ECVF_AMMETER_CAL
+         || g_EvseController.AmmeterCalEnabled()
+#endif 
+         ) && AmmeterIsDirty()) {
       SetAmmeterDirty(0);
 
       uint32_t current = g_EvseController.GetChargingCurrent();

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -717,7 +717,7 @@ void OnboardDisplay::Update(int8_t updmode)
 #ifdef LCD16X2 //Adafruit RGB LCD
       LcdSetBacklightColor(RED);
       if (updmode == OBD_UPD_HARDFAULT) {
-        LcdMsg_P(g_psEvseError,g_psNoGround);
+        LcdMsg_P(g_EvseController.CGMIisEnabled() ? g_psSvcReq : g_psEvseError,g_psNoGround);
       }
       else {
 	// 2nd line will be updated below with auto retry count
@@ -732,6 +732,15 @@ void OnboardDisplay::Update(int8_t updmode)
 #ifdef LCD16X2 //Adafruit RGB LCD
       LcdSetBacklightColor(RED);
       LcdMsg_P(updmode == OBD_UPD_HARDFAULT ? g_psSvcReq : g_psEvseError,g_psStuckRelay);
+#endif //Adafruit RGB LCD
+      // n.b. blue LED is off
+      break;
+    case EVSE_STATE_RELAY_CLOSURE_FAULT:
+      SetGreenLed(0);
+      SetRedLed(1);
+#ifdef LCD16X2 //Adafruit RGB LCD
+      LcdSetBacklightColor(RED);
+      LcdMsg_P(g_psSvcReq,g_psRelayClosureFault);
 #endif //Adafruit RGB LCD
       // n.b. blue LED is off
       break;

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -2,7 +2,7 @@
 /*
  * Open EVSE Firmware
  *
- * Copyright (c) 2013-2019 Sam C. Lin <lincomatic@gmail.com>
+ * Copyright (c) 2013-2021 Sam C. Lin <lincomatic@gmail.com>
  *
  * This file is part of Open EVSE.
 
@@ -420,6 +420,29 @@ int EvseRapiProcessor::processCmd()
       }
       break;
 #endif // AUTH_LOCK && !AUTH_LOCK_REG
+#ifdef MENNEKES_LOCK
+    case '5': // mennekes setting
+      if (tokenCnt == 2) {
+	rc = 0;
+        switch(*tokens[1]) {
+        case '0':
+          g_EvseController.UnlockMennekes();
+          break;
+        case '1':
+          g_EvseController.LockMennekes();
+          break;
+        case 'A':
+          g_EvseController.ClrMennekesManual();
+          break;
+        case 'M':
+          g_EvseController.SetMennekesManual();
+          break;
+        default:
+          rc = 1;
+        }
+      }
+      break;
+#endif // MENNEKES_LOCK
 #ifdef AMMETER
     case 'A':
       if (tokenCnt == 3) {
@@ -599,6 +622,14 @@ int EvseRapiProcessor::processCmd()
       rc = 0;
       break;
 #endif // AUTH_LOCK && !AUTH_LOCK_REG
+#ifdef MENNEKES_LOCK
+    case '5': // get mennekes setting
+      sprintf(buffer,"%d %c",g_EvseController.MennekesIsLocked(),
+              g_EvseController.MennekesIsManual() ? 'M' : 'A');
+      bufCnt = 1; // flag response text output
+      rc = 0;
+      break;
+#endif // MENNEKES_LOCK
 #ifdef AMMETER
     case 'A':
       u1.i = g_EvseController.GetCurrentScaleFactor();

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -393,14 +393,14 @@ int EvseRapiProcessor::processCmd()
       }
       break;
 #endif // RTC      
-#ifdef AMMETER
+#if defined(AMMETER) && defined(ECVF_AMMETER_CAL)
     case '2': // ammeter calibration mode
       if (tokenCnt == 2) {
 	g_EvseController.EnableAmmeterCal((*tokens[1] == '1') ? 1 : 0);
 	rc = 0;
       }
       break;
-#endif // AMMETER
+#endif // AMMETER && ECVF_AMMETER_CAL
 #ifdef TIME_LIMIT
     case '3': // set time limit
       if (tokenCnt == 2) {

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -2,7 +2,7 @@
 /*
  * Open EVSE Firmware
  *
- * Copyright (c) 2013-2019 Sam C. Lin <lincomatic@gmail.com>
+ * Copyright (c) 2013-2021 Sam C. Lin <lincomatic@gmail.com>
  *
  * This file is part of Open EVSE.
 
@@ -166,6 +166,12 @@ S4 0|1 - set auth lock (needs AUTH_LOCK defined and AUTH_LOCK_REG undefined)
    1 = locked - EVSE won't charge until unlocked
    when auth lock is on, will not transition to State C and a lock icon is
    displayed in States A & B.
+S5 A|M|0|1 - Mennekes lock setting
+   A = enable automatic mode - locked when connected, unlocked otherwise
+   M = enable manual control mode
+   0 = unlock (valid only in manual mode)
+   1 = lock (valid only in manual mode)
+   n.b. requires MENNEKES_LOCK. manual mode is volatile - always boots in automatic mode
 SA currentscalefactor currentoffset - set ammeter settings
 SC amps [V|M]- set current capacity
  response:
@@ -230,6 +236,16 @@ G4 - get auth lock (needs AUTH_LOCK defined and AUTH_LOCK_REG undefined)
  response: $OK lockstate
   lockstate = 0=unlocked, =1=locked
  $G4^57
+
+G5 - get Mennekes settings
+ response: $OK state mode
+   state: 0 = unlocked
+          1 = locked
+   mode: A = automatic mode - locked when connected, unlocked otherwise
+         M = manual control mode
+   Note: lock mode is also indicated by ECVF_MENNEKES_MANUAL
+   n.b. requires MENNEKES_LOCK
+
 GA - get ammeter settings
  response: $OK currentscalefactor currentoffset
  $GA^22
@@ -342,7 +358,7 @@ Z0 closems holdpwm
 
 #ifdef RAPI
 
-#define RAPIVER "5.1.4"
+#define RAPIVER "5.2.0"
 
 #define WIFI_MODE_AP 0
 #define WIFI_MODE_CLIENT 1

--- a/firmware/open_evse/strings.cpp
+++ b/firmware/open_evse/strings.cpp
@@ -103,7 +103,7 @@ const char g_psDisabled[] PROGMEM =  STR_DISABLED;
 const char g_psSleeping[] PROGMEM = STR_SLEEPING;
 const char g_psEvConnected[] PROGMEM = STR_CONNECTED;
 const char g_psResetting[] PROGMEM = STR_RESETTING;
-
+const char g_psRelayClosureFault[] PROGMEM = STR_RELAY_CLOSURE_FAULT;
 #ifdef SHOW_DISABLED_TESTS
 const char g_psDisabledTests[] PROGMEM = STR_TEST_DISABLED;
 #endif

--- a/firmware/open_evse/strings.h
+++ b/firmware/open_evse/strings.h
@@ -106,6 +106,7 @@ extern const char g_psNoGround[] PROGMEM;
 extern const char g_psStuckRelay[] PROGMEM;
 extern const char g_psDisabled[] PROGMEM;
 extern const char g_psResetting[] PROGMEM;
+extern const char g_psRelayClosureFault[] PROGMEM;
 //extern const char g_psWaiting[] PROGMEM;
 extern const char g_psSleeping[] PROGMEM;
 extern const char g_psEvConnected[] PROGMEM;


### PR DESCRIPTION
## 20220107

- set ECF_AUTO_SVC_LEVEL_DISABLED when !AUTOSVCLEVEL

## 20211216 SCL V8.1.1

- reset elapsed time when car plugged in
- J1772EvseController::Update() - just call ReadPilot() once at the top of function
    previously had ReadPilot() sprinkled around to try to avoid reading when not needed to save CPU cycles -> probably not necessary

## 20211216 SCL V8.1.0

- merged in mennekes branch

## 20211201 SCL V8.1.0a

- added ECVF_TIMER_ON so we don't have to poll to test if delay timer is on
- revamp MENNEKES_LOCK
  - auto mode: locked when EVSE connected, unlocked when disconnected
    - to implement this, need to get rid of states were pilot = N12, because we can't detect connection state
    - don't ever set pilot to N12, even in fault states. only set to N12 in EVSE_STATE_DISABLED
  - always automatically unlocks in EVSE_STATE_DISABLED, even if in manual mode
  - add recoverable parameter to HardFault()
  - add volatile manual mode - when enabled, Mennekes lock is under full manual control
  - add S5/G5 RAPI commands to set/fetch Mennekes settings
  - ECVF_MENNEKES_MANUAL also reflects auto/manual mode
- RAPIVER 5.2.0
- usurped ECVF_AMMETER_CAL with ECVF_MENNEKES_MANUAL, so the code is currently turned off

## 20211201 SCL V8.0.0d

- more refinements to CGMI - POST stuck relay check

## 20211128 SCL V8.0.0c

- fixed bugs in CGMI code

## 20211123 SCL V8.0.0a

- acpinstate: added ACPINx_OPEN
- first cut for CGMI - continuous GMI support:
  - PD4: at any time, if PD3 is low, declare EVSE_STATE_NO_GROUND.
  - PD3: we will read it only when we think the relay should be open. If we detect a low state on PD4 when the relay is supposed to be open, go to EVSE_STATE_STUCK_RELAY. This is exactly the current behaviour, except that we only monitor one pin.	
- take out SAMPLE_ACPINS #ifdef.. always sample
- added INVERT_V6_DETECTION: DO NOT USE 
  - only enabled for lincomatic's beta V6 board