### PR TITLE
Shifted voltmeter

### DIFF
--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -2248,7 +2248,17 @@ uint32_t J1772EVSEController::ReadVoltmeter()
     unsigned int val = adcVoltMeter.read();
     if (val > peak) peak = val;
   }
+#ifdef SHIFTED_VOLTMETER
+  // Since the sine is shifted upwards, remove offset, then multiply
+  // Also take care if the peak is somehow below offset, this would produce large values
+  // due to unsigned variables being used, clamp it to zero
+  m_Voltage = peak > m_VoltOffset? ((uint32_t)peak - m_VoltOffset) * ((uint32_t)m_VoltScaleFactor) : 0;
+  // Clamp down the noise to zero too
+  if (m_Voltage <= VOLTMETER_THRESHOLD)
+      m_Voltage = 0;
+#else
   m_Voltage = ((uint32_t)peak) * ((uint32_t)m_VoltScaleFactor) + m_VoltOffset;
+#endif
   return m_Voltage;
 }
 #endif // VOLTMETER

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -470,6 +470,14 @@ extern AutoCurrentCapacityController g_ACCController;
 // voltmeter pin is ADC2 on OPENEVSE_2
 #define VOLTMETER_PIN 2 // analog AC Line voltage voltmeter pin ADCx
 #endif // VOLTMETER_PIN
+// A shifted voltmeter scales the sine wave of input voltage down to ADC range and offsets it
+// upwards so that all the input is in positive range. A typical off the shelf unit will map
+// the zero input to half of VCC. This slightly changes the calculation compared to OPENEVSE_2.
+// Because we are operating with integers still, it might be useful to pick up a unit with gain
+// adjustment and only work with a scale factor of 1 or 2.
+#ifdef SHIFTED_VOLTMETER
+#define VOLTMETER_THRESHOLD (10)    // Values below this will be considered ADC noise TODO: this might be useful for other builds too
+#endif // SHIFTED_VOLTMETER
 #endif // VOLTMETER
 #ifdef OPENEVSE_2
 // This pin must match the last write to CHARGING_PIN, modulo a delay. If

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -155,15 +155,6 @@ extern AutoCurrentCapacityController g_ACCController;
 // If the AC voltage is > 150,000 mV, then it's L2. Else, L1.
 #define L2_VOLTAGE_THRESHOLD (150000)
 #define VOLTMETER
-// 35 ms is just a bit longer than 1.5 cycles at 50 Hz
-#define VOLTMETER_POLL_INTERVAL (35)
-// This is just a wild guess
-// #define VOLTMETER_SCALE_FACTOR (266)     // original guess
-//#define DEFAULT_VOLT_SCALE_FACTOR (262)        // calibrated for Craig K OpenEVSE II build
-#define DEFAULT_VOLT_SCALE_FACTOR (298)        // calibrated for lincomatic's OEII
-// #define VOLTMETER_OFFSET_FACTOR (40000)  // original guess
-//#define DEFAULT_VOLT_OFFSET (46800)     // calibrated for Craig K OpenEVSE II build
-#define DEFAULT_VOLT_OFFSET (12018)     // calibrated for lincomatic's OEII
 #endif // OPENEVSE_2
 
 // GFI support
@@ -461,9 +452,24 @@ extern AutoCurrentCapacityController g_ACCController;
 #define PILOT_PIN 1 // analog pilot voltage reading pin ADCx
 #define PP_PIN 2 // PP_READ - ADC2
 #ifdef VOLTMETER
+// 35 ms is just a bit longer than 1.5 cycles at 50 Hz
+#define VOLTMETER_POLL_INTERVAL (35)
+#ifndef DEFAULT_VOLT_SCALE_FACTOR
+// This is just a wild guess
+// #define VOLTMETER_SCALE_FACTOR (266)     // original guess
+//#define DEFAULT_VOLT_SCALE_FACTOR (262)        // calibrated for Craig K OpenEVSE II build
+#define DEFAULT_VOLT_SCALE_FACTOR (298)        // calibrated for lincomatic's OEII
+#endif // DEFAULT_VOLT_SCALE_FACTOR
+#ifndef DEFAULT_VOLT_OFFSET
+// #define VOLTMETER_OFFSET_FACTOR (40000)  // original guess
+//#define DEFAULT_VOLT_OFFSET (46800)     // calibrated for Craig K OpenEVSE II build
+#define DEFAULT_VOLT_OFFSET (12018)     // calibrated for lincomatic's OEII
+#endif // DEFAULT_VOLT_OFFSET
+#ifndef VOLTMETER_PIN
 // N.B. Note, ADC2 is already used as PP_PIN so beware of potential clashes
 // voltmeter pin is ADC2 on OPENEVSE_2
 #define VOLTMETER_PIN 2 // analog AC Line voltage voltmeter pin ADCx
+#endif // VOLTMETER_PIN
 #endif // VOLTMETER
 #ifdef OPENEVSE_2
 // This pin must match the last write to CHARGING_PIN, modulo a delay. If

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -157,6 +157,7 @@ extern AutoCurrentCapacityController g_ACCController;
 #define VOLTMETER
 #endif // OPENEVSE_2
 
+#ifndef NO_GFI
 // GFI support
 #define GFI
 
@@ -170,6 +171,7 @@ extern AutoCurrentCapacityController g_ACCController;
 // 2) if enabled, any a fault occurs immediately after charge is initiated,
 //    hard fault until power cycled. Otherwise, do the standard delay/retry sequence
 #define UL_COMPLIANT
+#endif // NO_GFI
 
 #ifdef UL_COMPLIANT
 #define ADVPWR

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -315,10 +315,12 @@ int EvseRapiProcessor::processCmd()
 	  case 'E': // command echo
 	    echo = ((u1.u8 == '0') ? 0 : 1);
 	    break;
-#ifdef ADVPWR
+#ifdef GFI_SELFTEST
 	  case 'F': // GFI self test
 	    g_EvseController.EnableGfiSelfTest(u1.u8);
 	    break;
+#endif
+#ifdef ADVPWR
 	  case 'G': // ground check
 	    g_EvseController.EnableGndChk(u1.u8);
 	    break;


### PR DESCRIPTION
I'm making a custom setup for development of a few features and needed a voltmeter for it. I have no idea what an OpenEVSE2 is and the code looks kind of dated, so I added support for a transformer based voltmeter that scales the input sine and puts it around half its VCC rather than zero. I bought it locally, so not sure how available it is, but seems to be quite common, called ZMPT101B. The thing looks like this just in case:
![image](https://user-images.githubusercontent.com/2434329/165378908-2f42e71e-ed34-4ffb-a7a9-cbaf89edb096.png)

It required a voltage caclulation logic alteration as well as subtracting the offset rather than adding, and since for some reason those are unsigned for voltage (why? they are signed for current), I added a define. I also made the voltmeter-related defines redefinable in build time.

There's an additional commit allowing to drop GFI support in build-time, it doesn't really relate to the voltmeter code, but I threw it for good measure, as it might be useful for someone.  (My setup has an external GFI unit)

PS: The "shifted voltmeter" name seems dumb, but I can't honestly think of anything better